### PR TITLE
Fixed string on unconfigured projects

### DIFF
--- a/tools/run.js
+++ b/tools/run.js
@@ -52,7 +52,7 @@ module.exports = (portReq) => {
       console.log(`Vector setup running on http://localhost:${port}`);
     } else {
       console.log("Seems like you have missed this step 'configure'!");
-      console.log("E.g. 'npm run vector-setup configure'");
+      console.log("E.g. 'vector-web-setup configure'");
     }
   } catch (err) {
     console.log(err);


### PR DESCRIPTION
This pull request changes the log string for unconfigured projects to `vector-web-setup configure`