### PR TITLE
Update pterm.js for an unexception

### DIFF
--- a/site/js/pterm.js
+++ b/site/js/pterm.js
@@ -437,7 +437,7 @@ function pterm_process_key(event) {
       pterm_current_pos--;
     }
   }
-  else if((32 <= event.keyCode && event.keyCode <= 126) || (event.key.length == 1)) {
+  else if((32 <= event.keyCode && event.keyCode <= 126) || (event.key && event.key.length == 1)) {
     let key = event.key;
 
     pterm_current_line = pterm_current_line.substring(0, pterm_current_pos) + 


### PR DESCRIPTION
Fixes an error where events.key.length undefined throws exception like this:
pterm.js:440 Uncaught TypeError: Cannot read property 'length' of undefined
    at pterm_process_key (pterm.js:440)
    at HTMLDocument.<anonymous> (pterm.js:312)
    at HTMLDocument.dispatch (jquery.min.3.3.1.js:2)
    at HTMLDocument.y.handle (jquery.min.3.3.1.js:2)


