### PR TITLE
SSL Support

### DIFF
--- a/tools/run.js
+++ b/tools/run.js
@@ -7,6 +7,7 @@ const path = require("path");
 const bodyParser = require("body-parser");
 const fs = require("fs");
 const cors = require("cors");
+const https = require('https');
 
 const fsPromise = require("../utils/fsPromise");
 const { getNetworkIp } = require("../utils/ip");
@@ -48,12 +49,16 @@ app.post("/firmware", async (req, res) => {
   }
 });
 
+const key = fs.readFileSync('key.pem');
+const cert = fs.readFileSync('cert.pem');
+const server = https.createServer({key: key, cert: cert }, app);
+
 const startServer = (portReq, ipReq) => {
   port = portReq === undefined ? 8000 : portReq;
   serverIp = ipReq === undefined ? "0.0.0.0" : ipReq;
 
   app
-    .listen(port, serverIp, () => {
+    server.listen(port, serverIp, () => {
       console.log(`Server running on ip ${serverIp} and port ${port}`);
 
       let ipToShow = serverIp;
@@ -88,13 +93,9 @@ const startServer = (portReq, ipReq) => {
       }
     });
 };
-
 module.exports = (portReq, ipReq) => {
   try {
-    if (
-      fs.existsSync(filePath.SETTINGS_FILE) &&
-      fs.existsSync(filePath.INVENTORY_FILE)
-    ) {
+    if (fs.existsSync(filePath.SETTINGS_FILE)) {
       startServer(portReq, ipReq);
     } else {
       console.log("Seems like you have missed this step 'configure'!");

--- a/tools/run.js
+++ b/tools/run.js
@@ -93,9 +93,13 @@ const startServer = (portReq, ipReq) => {
       }
     });
 };
+
 module.exports = (portReq, ipReq) => {
   try {
-    if (fs.existsSync(filePath.SETTINGS_FILE)) {
+    if (
+      fs.existsSync(filePath.SETTINGS_FILE) &&
+      fs.existsSync(filePath.INVENTORY_FILE)
+    ) {
       startServer(portReq, ipReq);
     } else {
       console.log("Seems like you have missed this step 'configure'!");


### PR DESCRIPTION
Linux info

In your working directory (run command "pwd" to find what your current working directory is), have a cert.pem and a key.pem. (Must be a valid keypair generated) when you run "vector-web-setup serve" and it will create a https connection.

The following flag may need enabling as per this site --> https://developer.mozilla.org/en-US/docs/Web/API/Bluetooth#browser_compatibility
opera://flags/#enable-experimental-web-platform-features
chrome://flags/#enable-experimental-web-platform-features

If you get a message about chrome required. This will resolve this issue, as for bluetooth capability, service either requires localhost or https connection.

Not sure why my version of the file has a line missing at the bottom, this isn't a change i've made. will most likely restore this to original.